### PR TITLE
docs: Update link to general contributing process document

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -29,7 +29,7 @@ $ python3 wsgi.py
 
 ## Contributing
 
-We describe our [general contributing process](https://lyft.github.io/amundsen/CONTRIBUTING/) in the main repository of Amundsen, so here we'll cover the items specific to the Frontend library.
+We describe our [general contributing process](https://github.com/amundsen-io/amundsen/blob/master/CONTRIBUTING.md) in the main repository of Amundsen, so here we'll cover the items specific to the Frontend library.
 
 ### Testing Python Code
 


### PR DESCRIPTION
docs:

The existing link leads to a NOT FOUND page. This fixes that.

### Summary of Changes

Update link to the general contributing process document.

### Tests

No tests modified because it's a documentation change.

### Documentation

Fixed a broken link to the general contributing process document.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
